### PR TITLE
Set up initial Confluence connectivity

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,5 +55,3 @@ jobs:
           space_key: GAT  # Github Action Test
           username: ${{ secrets.CONFLUENCE_USER }}
           password: ${{ secrets.CONFLUENCE_APIKEY }}
-        env:
-          ACTIONS_STEP_DEBUG: true

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -55,3 +55,5 @@ jobs:
           space_key: GAT  # Github Action Test
           username: ${{ secrets.CONFLUENCE_USER }}
           password: ${{ secrets.CONFLUENCE_APIKEY }}
+        env:
+          ACTIONS_STEP_DEBUG: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ COPY --from=compiler dist ./
 
 RUN yarn install --production --frozen-lockfile
 
-ENTRYPOINT ["node", "main.js"]
+ENTRYPOINT ["node", "/main.js"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,14 @@ The Action will use the README.md of the repository as the root page titled with
 The `source_dir` is a relative path inside the repository to the location of the Markdown files that you wish to render in Confluence.
 See below for more details and how to configure this action.
 
+See the output of this action from the [CI workflow](/.github/workflows/pr.yml) at <https://artis3nal.atlassian.net/wiki/spaces/GAT/>.
+
 # Usage
 
 You must minimally supply a `confluence_url`, `space_key`, `username`, and `password` to use this Action.
+
+:exclamation: To be filled in
+
+## Debug logging
+
+Follow GitHub's instructions for [step debug logging](https://docs.github.com/en/free-pro-team@latest/actions/managing-workflow-runs/enabling-debug-logging#enabling-step-debug-logging) to enable debug output in this action.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,6 @@ The Action will use the README.md of the repository as the root page titled with
 The `source_dir` is a relative path inside the repository to the location of the Markdown files that you wish to render in Confluence.
 See below for more details and how to configure this action.
 
-# Requirements
+# Usage
 
-You must supply a `confluence_url`, 
+You must minimally supply a `confluence_url`, `space_key`, `username`, and `password` to use this Action.

--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,10 @@ inputs:
     description: The username with which to authenticate to Confluence.
     required: true
   password:
-    description: The API token or password with which to authenticate to Confluence.
+    description: |
+      The API token or password with which to authenticate to Confluence.
+
+      For Confluence Cloud, you can generate an API token at https://id.atlassian.com/manage/api-tokens.
     required: true
   base_url:
     description: |
@@ -48,16 +51,6 @@ inputs:
       Defaults to the repo root.
     required: false
     default: './'
-  debug_mode:
-    description: |
-      Enable debug mode, which prints out verbose information about the wiki conversion process.
-      Useful to debug connectivity issues between the GitHub Action and your Confluence instance.
-
-      Options: [true, false] (strings)
-
-      Default: false
-    required: false
-    default: 'false'
   code_theme:
     description: |
       What Confluence code theme to apply to code blocks. Must be a valid Confluence code block theme.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-to-confluence",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "description": "GitHub Action to render a GitHub repository of Markdown content into a Confluence page and series of sub-pages.",
   "main": "dist/main.js",
   "repository": "https://github.com/artis3n/markdown-to-confluence",

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ const convertedMarkdown = convert(content, {
     codeTheme: getInput("code_theme"),
   });
 
-  const confluence = new Confluence(confluenceUrl, auth, spaceKey);
+  const confluence = new Confluence(confluenceUrl, auth, "TS");
   const page: ConfluencePage = {
     title: "Markdown Test",
     body: markup,

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { AxiosResponse } from "axios";
 import curlirize from "axios-curlirize";
 import { debug, error, getInput, info, setFailed } from "@actions/core";
-import github from "@actions/github";
+import { context as githubContext } from "@actions/github";
 import { convertToConfluenceWiki } from "./markdownProcessor";
 import { Confluence } from "./Confluence";
 import {
@@ -49,8 +49,6 @@ async function main() {
     error(errMsg);
     throw new Error(errMsg);
   }
-
-  const githubContext = github.context;
 
   let baseUrl = getInput("base_url");
   if (baseUrl === "") {

--- a/src/main.ts
+++ b/src/main.ts
@@ -13,12 +13,16 @@ import {
 import { StatusCodes } from "http-status-codes";
 
 const axios = require("axios").default;
+curlirize(axios, (result, err) => {
+  const { command } = result;
+  if (err) {
+    error(err);
+  } else {
+    debug(command);
+  }
+});
 
 async function main() {
-  if (getInput("debug_mode").toLowerCase() === "true") {
-    curlirize(axios);
-  }
-
   let confluenceUrl = getInput("confluence_url");
   if (confluenceUrl === "") {
     throw new Error(
@@ -121,6 +125,9 @@ const convertedMarkdown = convert(content, {
         );
       }
     } else {
+      error(
+        `${err.response.status} ${err.response.statusTest}: ${err.response?.data.reason} : ${err.response?.data.message}`
+      );
       setFailed(
         `Error occurred attempting to update Confluence on page: ${page.title}`
       );

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ const convertedMarkdown = convert(content, {
     codeTheme: getInput("code_theme"),
   });
 
-  const confluence = new Confluence(confluenceUrl, auth, "TS");
+  const confluence = new Confluence(confluenceUrl, auth, spaceKey);
   const page: ConfluencePage = {
     title: "Markdown Test",
     body: markup,

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,10 +21,9 @@ async function main() {
 
   let confluenceUrl = getInput("confluence_url");
   if (confluenceUrl === "") {
-    const errMsg =
-      "'confluence_url' input parameter is not defined. You must specify your Confluence host.";
-    error(errMsg);
-    throw new Error(errMsg);
+    throw new Error(
+      "'confluence_url' input parameter is not defined. You must specify your Confluence host."
+    );
   }
   // Remove trailing slash if present
   if (confluenceUrl.endsWith("/")) {
@@ -33,10 +32,9 @@ async function main() {
 
   const spaceKey = getInput("space_key");
   if (spaceKey === "") {
-    const errMsg =
-      "'space_key' input parameter is not defined. You must specify your Confluence Space Key.";
-    error(errMsg);
-    throw new Error(errMsg);
+    throw new Error(
+      "'space_key' input parameter is not defined. You must specify your Confluence Space Key."
+    );
   }
 
   const auth: ConfluenceAuth = {
@@ -44,10 +42,9 @@ async function main() {
     password: getInput("password"),
   };
   if (auth.username === "" || auth.password === "") {
-    const errMsg =
-      "'username' or 'password' input parameters are not defined. You must specify a Confluence user and a corresponding API token or password.";
-    error(errMsg);
-    throw new Error(errMsg);
+    throw new Error(
+      "'username' or 'password' input parameters are not defined. You must specify a Confluence user and a corresponding API token or password."
+    );
   }
 
   let baseUrl = getInput("base_url");

--- a/src/main.ts
+++ b/src/main.ts
@@ -132,5 +132,5 @@ const convertedMarkdown = convert(content, {
 }
 
 main()
-    .then(() => {})
-    .catch((error) => setFailed(error));
+  .then(() => {})
+  .catch((error) => setFailed(error));

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,8 +40,8 @@ async function main() {
   }
 
   const auth: ConfluenceAuth = {
-    username: getInput("username") || "admin",
-    password: getInput("password") || "admin",
+    username: getInput("username"),
+    password: getInput("password"),
   };
   if (auth.username === "" || auth.password === "") {
     const errMsg =
@@ -131,10 +131,6 @@ const convertedMarkdown = convert(content, {
   }
 }
 
-try {
-  main()
+main()
     .then(() => {})
     .catch((error) => setFailed(error));
-} catch (error) {
-  setFailed(error);
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -85,7 +85,7 @@ const convertedMarkdown = convert(content, {
     codeTheme: getInput("code_theme"),
   });
 
-  const confluence = new Confluence(confluenceUrl, auth, "TS");
+  const confluence = new Confluence(confluenceUrl, auth, spaceKey);
   const page: ConfluencePage = {
     title: "Markdown Test",
     body: markup,
@@ -125,9 +125,16 @@ const convertedMarkdown = convert(content, {
         );
       }
     } else {
-      error(
-        `${err.response.status} ${err.response.statusTest}: ${err.response?.data.reason} : ${err.response?.data.message}`
-      );
+      error(`${err.response.status} : ${err.response?.data.message}`);
+      if (
+        err.response?.data?.message.includes(
+          "Could not create content with type page"
+        )
+      ) {
+        error(
+          `Check your permissions to create content on Space key ${spaceKey}. Does this space exist on ${confluenceUrl} ?`
+        );
+      }
       setFailed(
         `Error occurred attempting to update Confluence on page: ${page.title}`
       );


### PR DESCRIPTION
The scope of this PR is connectivity to Confluence. This was tested against Confluence Cloud, which is publicly available linked below, and a trial instance of Confluence Server on a temporary EC2 instance. Can't link to that as it no longer exists, but the action successfully generated pages on both of them.

This PR is updating the Confluence space at <https://artis3nal.atlassian.net/wiki/spaces/GAT/>.

Issues:

- Relative links are not being rewritten correctly. Instead of taking the `baseUrl`, they are relative to the Confluence URL.